### PR TITLE
Use "UNSAFE" keyword in docstring to represent unsafe list operations

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,9 +3,10 @@ pipeline:
     image: mesalocklinux/build-mesalock-linux
     pull: true
     commands:
+      - git checkout -b temp-branch-name # make a temp branch name to work around a issue in building process
       - export PYPY_USESSION_DIR=$(pwd)/pypy-usession-dir
       - mkdir pypy-usession-dir
-      - /bin/bash -c "make pypy-c"
+      - make pypy-c
   package:
     image: mesalocklinux/build-mesalock-linux
     commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ pipeline:
     commands:
       - export PYPY_USESSION_DIR=$(pwd)/pypy-usession-dir
       - mkdir pypy-usession-dir
-      - make pypy-c
+      - /bin/bash -c "make pypy-c"
   package:
     image: mesalocklinux/build-mesalock-linux
     commands:

--- a/rpython/flowspace/pygraph.py
+++ b/rpython/flowspace/pygraph.py
@@ -16,7 +16,10 @@ class PyGraph(FunctionGraph):
             locals[i] = Variable(code.co_varnames[i])
         state = FrameState(locals, [], None, [], 0)
         initialblock = SpamBlock(state)
-        super(PyGraph, self).__init__(self._sanitize_funcname(func), initialblock)
+        unsafe = False
+        if func.func_doc and func.func_doc.lstrip().startswith('UNSAFE'):
+            unsafe = True
+        super(PyGraph, self).__init__(self._sanitize_funcname(func), initialblock, unsafe=unsafe)
         self.func = func
         self.signature = code.signature
         self.defaults = func.func_defaults or ()

--- a/rpython/rlib/rbigint.py
+++ b/rpython/rlib/rbigint.py
@@ -159,23 +159,24 @@ class rbigint(object):
         return not (self == other)
 
     def digit(self, x):
-        """Return the x'th digit, as an int."""
+        """UNSAFE Return the x'th digit, as an int."""
         return self._digits[x]
     digit._always_inline_ = True
 
     def widedigit(self, x):
-        """Return the x'th digit, as a long long int if needed
+        """UNSAFE Return the x'th digit, as a long long int if needed
         to have enough room to contain two digits."""
         return _widen_digit(self._digits[x])
     widedigit._always_inline_ = True
 
     def udigit(self, x):
-        """Return the x'th digit, as an unsigned int."""
+        """UNSAFE Return the x'th digit, as an unsigned int."""
         return _load_unsigned_digit(self._digits[x])
     udigit._always_inline_ = True
 
     @specialize.argtype(2)
     def setdigit(self, x, val):
+        """UNSAFE"""
         val = _mask_digit(val)
         assert val >= 0
         self._digits[x] = _store_digit(val)
@@ -188,6 +189,7 @@ class rbigint(object):
     @staticmethod
     @jit.elidable
     def fromint(intval):
+        """UNSAFE"""
         # This function is marked as pure, so you must not call it and
         # then modify the result.
         check_regular_int(intval)
@@ -235,6 +237,7 @@ class rbigint(object):
     @staticmethod
     @jit.elidable
     def _fromfloat_finite(dval):
+        """UNSAFE"""
         sign = 1
         if dval < 0.0:
             sign = -1
@@ -272,7 +275,7 @@ class rbigint(object):
     @staticmethod
     @jit.elidable
     def fromstr(s, base=0, allow_underscores=False):
-        """As string_to_int(), but ignores an optional 'l' or 'L' suffix
+        """UNSAFE As string_to_int(), but ignores an optional 'l' or 'L' suffix
         and returns an rbigint."""
         from rpython.rlib.rstring import NumberStringParser, \
             strip_spaces
@@ -291,6 +294,7 @@ class rbigint(object):
     @staticmethod
     @jit.elidable
     def frombytes(s, byteorder, signed):
+        """UNSAFE"""
         if byteorder not in ('big', 'little'):
             raise InvalidEndiannessError()
         if not s:
@@ -331,6 +335,7 @@ class rbigint(object):
 
     @jit.elidable
     def tobytes(self, nbytes, byteorder, signed):
+        """UNSAFE"""
         if byteorder not in ('big', 'little'):
             raise InvalidEndiannessError()
         if not signed and self.sign == -1:
@@ -495,6 +500,7 @@ class rbigint(object):
 
     @jit.elidable
     def eq(self, other):
+        """UNSAFE"""
         if (self.sign != other.sign or
             self.numdigits() != other.numdigits()):
             return False
@@ -509,7 +515,7 @@ class rbigint(object):
 
     @jit.elidable
     def int_eq(self, other):
-        """ eq with int """
+        """UNSAFE eq with int """
         
         if not int_in_valid_range(other):
             # Fallback to Long. 
@@ -528,6 +534,7 @@ class rbigint(object):
 
     @jit.elidable
     def lt(self, other):
+        """UNSAFE"""
         if self.sign > other.sign:
             return False
         if self.sign < other.sign:
@@ -563,7 +570,7 @@ class rbigint(object):
 
     @jit.elidable
     def int_lt(self, other):
-        """ lt where other is an int """
+        """UNSAFE lt where other is an int """
 
         if not int_in_valid_range(other):
             # Fallback to Long.
@@ -622,6 +629,7 @@ class rbigint(object):
 
     @jit.elidable
     def add(self, other):
+        """UNSAFE"""
         if self.sign == 0:
             return other
         if other.sign == 0:
@@ -635,6 +643,7 @@ class rbigint(object):
 
     @jit.elidable
     def int_add(self, other):
+        """UNSAFE"""
         if not int_in_valid_range(other):
             # Fallback to long.
             return self.add(rbigint.fromint(other))
@@ -654,6 +663,7 @@ class rbigint(object):
 
     @jit.elidable
     def sub(self, other):
+        """UNSAFE"""
         if other.sign == 0:
             return self
         elif self.sign == 0:
@@ -667,6 +677,7 @@ class rbigint(object):
 
     @jit.elidable
     def int_sub(self, other):
+        """UNSAFE"""
         if not int_in_valid_range(other):
             # Fallback to long.
             return self.sub(rbigint.fromint(other))
@@ -683,6 +694,7 @@ class rbigint(object):
 
     @jit.elidable
     def mul(self, b):
+        """UNSAFE"""
         asize = self.numdigits()
         bsize = b.numdigits()
 
@@ -726,6 +738,7 @@ class rbigint(object):
 
     @jit.elidable
     def int_mul(self, b):
+        """UNSAFE"""
         if not int_in_valid_range(b):
             # Fallback to long.
             return self.mul(rbigint.fromint(b))
@@ -757,11 +770,13 @@ class rbigint(object):
 
     @jit.elidable
     def truediv(self, other):
+        """UNSAFE"""
         div = _bigint_true_divide(self, other)
         return div
 
     @jit.elidable
     def floordiv(self, other):
+        """UNSAFE"""
         if self.sign == 1 and other.numdigits() == 1 and other.sign == 1:
             digit = other.digit(0)
             if digit == 1:
@@ -778,10 +793,12 @@ class rbigint(object):
         return div
 
     def div(self, other):
+        """UNSAFE"""
         return self.floordiv(other)
 
     @jit.elidable
     def mod(self, other):
+        """UNSAFE"""
         if other.sign == 0:
             raise ZeroDivisionError("long division or modulo by zero")
         if self.sign == 0:
@@ -799,6 +816,7 @@ class rbigint(object):
 
     @jit.elidable
     def int_mod(self, other):
+        """UNSAFE"""
         if other == 0:
             raise ZeroDivisionError("long division or modulo by zero")
         if self.sign == 0:
@@ -842,7 +860,7 @@ class rbigint(object):
 
     @jit.elidable
     def divmod(v, w):
-        """
+        """UNSAFE
         The / and % operators are now defined in terms of divmod().
         The expression a mod b has the value a - b*floor(a/b).
         The _divrem function gives the remainder after division of
@@ -868,6 +886,7 @@ class rbigint(object):
 
     @jit.elidable
     def pow(a, b, c=None):
+        """UNSAFE"""
         negativeOutput = False  # if x<0 return negative output
 
         # 5-ary values.  If the exponent is large enough, table is
@@ -1008,16 +1027,19 @@ class rbigint(object):
 
     @jit.elidable
     def neg(self):
+        """UNSAFE"""
         return rbigint(self._digits, -self.sign, self.size)
 
     @jit.elidable
     def abs(self):
+        """UNSAFE"""
         if self.sign != -1:
             return self
         return rbigint(self._digits, 1, self.size)
 
     @jit.elidable
     def invert(self): #Implement ~x as -(x + 1)
+        """UNSAFE"""
         if self.sign == 0:
             return ONENEGATIVERBIGINT
 
@@ -1027,6 +1049,7 @@ class rbigint(object):
 
     @jit.elidable
     def lshift(self, int_other):
+        """UNSAFE"""
         if int_other < 0:
             raise ValueError("negative shift count")
         elif int_other == 0:
@@ -1064,6 +1087,7 @@ class rbigint(object):
 
     @jit.elidable
     def lqshift(self, int_other):
+        """UNSAFE"""
         " A quicker one with much less checks, int_other is valid and for the most part constant."
         assert int_other > 0
 
@@ -1084,6 +1108,7 @@ class rbigint(object):
 
     @jit.elidable
     def rshift(self, int_other, dont_invert=False):
+        """UNSAFE"""
         if int_other < 0:
             raise ValueError("negative shift count")
         elif int_other == 0:
@@ -1114,6 +1139,7 @@ class rbigint(object):
 
     @jit.elidable
     def abs_rshift_and_mask(self, bigshiftcount, mask):
+        """UNSAFE"""
         assert isinstance(bigshiftcount, r_ulonglong)
         assert mask >= 0
         wordshift = bigshiftcount / SHIFT
@@ -1130,6 +1156,7 @@ class rbigint(object):
 
     @staticmethod
     def from_list_n_bits(list, nbits):
+        """UNSAFE"""
         if len(list) == 0:
             return NULLRBIGINT
 
@@ -1198,6 +1225,7 @@ class rbigint(object):
 
     @jit.elidable
     def log(self, base):
+        """UNSAFE"""
         # base is supposed to be positive or 0.0, which means we use e
         if base == 10.0:
             return _loghelper(math.log10, self)
@@ -1211,6 +1239,7 @@ class rbigint(object):
 
     @not_rpython
     def tolong(self):
+        """UNSAFE"""
         l = 0L
         digits = list(self._digits)
         digits.reverse()
@@ -1220,6 +1249,7 @@ class rbigint(object):
         return l * self.sign
 
     def _normalize(self):
+        """UNSAFE"""
         i = self.numdigits()
 
         while i > 1 and self._digits[i - 1] == NULLDIGIT:
@@ -1236,6 +1266,7 @@ class rbigint(object):
 
     @jit.elidable
     def bit_length(self):
+        """UNSAFE"""
         i = self.numdigits()
         if i == 1 and self._digits[0] == NULLDIGIT:
             return 0
@@ -1279,6 +1310,7 @@ MAX_DIGITS_THAT_CAN_FIT_IN_INT = rbigint.fromint(-sys.maxint - 1).numdigits()
 
 
 def _help_mult(x, y, c):
+    """UNSAFE"""
     """
     Multiply two values, then reduce the result:
     result = X*Y % c.  If c is None, skip the mod.
@@ -1293,6 +1325,7 @@ def _help_mult(x, y, c):
 
 @specialize.argtype(0)
 def digits_from_nonneg_long(l):
+    """UNSAFE"""
     digits = []
     while True:
         digits.append(_store_digit(_mask_digit(l & MASK)))
@@ -1302,6 +1335,7 @@ def digits_from_nonneg_long(l):
 
 @specialize.argtype(0)
 def digits_for_most_neg_long(l):
+    """UNSAFE"""
     # This helper only works if 'l' is the most negative integer of its
     # type, which in base 2 looks like: 1000000..0000
     digits = []
@@ -1318,6 +1352,7 @@ def digits_for_most_neg_long(l):
 
 @specialize.argtype(0)
 def args_from_rarith_int1(x):
+    """UNSAFE"""
     if x > 0:
         return digits_from_nonneg_long(x), 1
     elif x == 0:
@@ -1331,12 +1366,14 @@ def args_from_rarith_int1(x):
 
 @specialize.argtype(0)
 def args_from_rarith_int(x):
+    """UNSAFE"""
     return args_from_rarith_int1(widen(x))
 # ^^^ specialized by the precise type of 'x', which is typically a r_xxx
 #     instance from rlib.rarithmetic
 
 @not_rpython
 def args_from_long(x):
+    """UNSAFE"""
     if x >= 0:
         if x == 0:
             return [NULLDIGIT], 0
@@ -1346,7 +1383,8 @@ def args_from_long(x):
         return digits_from_nonneg_long(-x), -1
 
 def _x_add(a, b):
-    """ Add the absolute values of two bigint integers. """
+    """UNSAFE
+    Add the absolute values of two bigint integers. """
     size_a = a.numdigits()
     size_b = b.numdigits()
 
@@ -1372,7 +1410,8 @@ def _x_add(a, b):
     return z
 
 def _x_int_add(a, b):
-    """ Add the absolute values of one bigint and one integer. """
+    """UNSAFE
+    Add the absolute values of one bigint and one integer. """
     size_a = a.numdigits()
 
     z = rbigint([NULLDIGIT] * (size_a + 1), 1)
@@ -1391,7 +1430,8 @@ def _x_int_add(a, b):
     return z
 
 def _x_sub(a, b):
-    """ Subtract the absolute values of two integers. """
+    """UNSAFE
+    Subtract the absolute values of two integers. """
 
     size_a = a.numdigits()
     size_b = b.numdigits()
@@ -1437,7 +1477,8 @@ def _x_sub(a, b):
     return z
 
 def _x_int_sub(a, b):
-    """ Subtract the absolute values of two integers. """
+    """UNSAFE
+    Subtract the absolute values of two integers. """
 
     size_a = a.numdigits()
 
@@ -1479,7 +1520,7 @@ for x in range(SHIFT-1):
     ptwotable[r_longlong(-2 << x)] = x+1
 
 def _x_mul(a, b, digit=0):
-    """
+    """UNSAFE
     Grade school multiplication, ignoring the signs.
     Returns the absolute value of the product, or None if error.
     """
@@ -1590,7 +1631,7 @@ def _x_mul(a, b, digit=0):
     return z
 
 def _kmul_split(n, size):
-    """
+    """UNSAFE
     A helper for Karatsuba multiplication (k_mul).
     Takes a bigint "n" and an integer "size" representing the place to
     split, and sets low and high such that abs(n) == (high << size) + low,
@@ -1608,7 +1649,7 @@ def _kmul_split(n, size):
     return hi, lo
 
 def _k_mul(a, b):
-    """
+    """UNSAFE
     Karatsuba multiplication.  Ignores the input signs, and returns the
     absolute value of the product (or raises if error).
     See Knuth Vol. 2 Chapter 4.3.3 (Pp. 294-295).
@@ -1755,7 +1796,7 @@ ah*bh and al*bl too.
 def _k_lopsided_mul(a, b):
     # Not in use anymore, only account for like 1% performance. Perhaps if we
     # Got rid of the extra list allocation this would be more effective.
-    """
+    """UNSAFE
     b has at least twice the digits of a, and a is big enough that Karatsuba
     would pay off *if* the inputs had balanced sizes.  View b as a sequence
     of slices, each with a->ob_size digits, and multiply the slices by a,
@@ -1805,7 +1846,7 @@ def _k_lopsided_mul(a, b):
     return ret
 
 def _inplace_divrem1(pout, pin, n):
-    """
+    """UNSAFE
     Divide bigint pin by non-zero digit n, storing quotient
     in pout, and returning the remainder. It's OK for pin == pout on entry.
     """
@@ -1821,7 +1862,7 @@ def _inplace_divrem1(pout, pin, n):
     return rffi.cast(lltype.Signed, rem)
 
 def _divrem1(a, n):
-    """
+    """UNSAFE
     Divide a bigint integer by a digit, returning both the quotient
     and the remainder as a tuple.
     The sign of a is ignored; n should not be zero.
@@ -1835,8 +1876,7 @@ def _divrem1(a, n):
     return z, rem
 
 def _v_iadd(x, xofs, m, y, n):
-    """
-    x and y are rbigints, m >= n required.  x.digits[0:n] is modified in place,
+    """UNSAFE x and y are rbigints, m >= n required.  x.digits[0:n] is modified in place,
     by adding y.digits[0:m] to it.  Carries are propagated as far as
     x[m-1], and the remaining carry (0 or 1) is returned.
     Python adaptation: x is addressed relative to xofs!
@@ -1860,8 +1900,7 @@ def _v_iadd(x, xofs, m, y, n):
     return carry
 
 def _v_isub(x, xofs, m, y, n):
-    """
-    x and y are rbigints, m >= n required.  x.digits[0:n] is modified in place,
+    """UNSAFE x and y are rbigints, m >= n required.  x.digits[0:n] is modified in place,
     by substracting y.digits[0:m] to it. Borrows are propagated as
     far as x[m-1], and the remaining borrow (0 or 1) is returned.
     Python adaptation: x is addressed relative to xofs!
@@ -1888,7 +1927,7 @@ def _v_isub(x, xofs, m, y, n):
 
 @specialize.argtype(2)
 def _muladd1(a, n, extra=0):
-    """Multiply by a single digit and add a single digit, ignoring the sign.
+    """UNSAFE Multiply by a single digit and add a single digit, ignoring the sign.
     """
 
     size_a = a.numdigits()
@@ -1906,7 +1945,7 @@ def _muladd1(a, n, extra=0):
     return z
 
 def _v_lshift(z, a, m, d):
-    """ Shift digit vector a[0:m] d bits left, with 0 <= d < SHIFT. Put
+    """UNSAFE Shift digit vector a[0:m] d bits left, with 0 <= d < SHIFT. Put
         * result in z[0:m], and return the d bits shifted out of the top.
     """
 
@@ -1922,7 +1961,7 @@ def _v_lshift(z, a, m, d):
     return carry
 
 def _v_rshift(z, a, m, d):
-    """ Shift digit vector a[0:m] d bits right, with 0 <= d < PyLong_SHIFT. Put
+    """UNSAFE Shift digit vector a[0:m] d bits right, with 0 <= d < PyLong_SHIFT. Put
         * result in z[0:m], and return the d bits shifted out of the bottom.
     """
 
@@ -1941,7 +1980,7 @@ def _v_rshift(z, a, m, d):
     return carry
 
 def _x_divrem(v1, w1):
-    """ Unsigned bigint division with remainder -- the algorithm """
+    """UNSAFE Unsigned bigint division with remainder -- the algorithm """
     size_v = v1.numdigits()
     size_w = w1.numdigits()
     assert size_v >= size_w and size_w > 1
@@ -2031,7 +2070,7 @@ def _x_divrem(v1, w1):
     return a, w
 
 def _divrem(a, b):
-    """ Long division with remainder, top-level routine """
+    """UNSAFE Long division with remainder, top-level routine """
     size_a = a.numdigits()
     size_b = b.numdigits()
 
@@ -2061,7 +2100,7 @@ def _divrem(a, b):
 # ______________ conversions to double _______________
 
 def _AsScaledDouble(v):
-    """
+    """ UNSAFE
     NBITS_WANTED should be > the number of bits in a double's precision,
     but small enough so that 2**NBITS_WANTED is within the normal double
     range.  nbitsneeded is set to 1 less than that because the most-significant
@@ -2108,7 +2147,7 @@ def _AsScaledDouble(v):
 
 @jit.dont_look_inside
 def _AsDouble(n):
-    """ Get a C double from a bigint object. """
+    """UNSAFE Get a C double from a bigint object. """
     # This is a "correctly-rounded" version from Python 2.7.
     #
     from rpython.rlib import rfloat
@@ -2158,7 +2197,7 @@ def _AsDouble(n):
 
 @specialize.arg(0)
 def _loghelper(func, arg):
-    """
+    """UNSAFE
     A decent logarithm is easy to compute even for huge bigints, but libm can't
     do that by itself -- loghelper can.  func is log or log10.
     Note that overflow isn't possible:  a bigint can contain
@@ -2184,6 +2223,7 @@ BitLengthTable = ''.join(map(chr, [
     5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5]))
 
 def bits_in_digit(d):
+    """UNSAFE"""
     # returns the unique integer k such that 2**(k-1) <= d <
     # 2**k if d is nonzero, else 0.
     d_bits = 0
@@ -2194,14 +2234,17 @@ def bits_in_digit(d):
     return d_bits
 
 def _truediv_result(result, negate):
+    """UNSAFE"""
     if negate:
         result = -result
     return result
 
 def _truediv_overflow():
+    """UNSAFE"""
     raise OverflowError("integer division result too large for a float")
 
 def _bigint_true_divide(a, b):
+    """UNSAFE"""
     # A longish method to obtain the floating-point result with as much
     # precision as theoretically possible.  The code is almost directly
     # copied from CPython.  See there (Objects/longobject.c,
@@ -2332,6 +2375,7 @@ BASE10 = '0123456789'
 BASE16 = '0123456789abcdef'
 
 def _format_base2_notzero(a, digits, prefix='', suffix=''):
+        """UNSAFE"""
         base = len(digits)
         # JRH: special case for power-of-2 bases
         accum = 0
@@ -2389,6 +2433,7 @@ def _format_base2_notzero(a, digits, prefix='', suffix=''):
 
 class _PartsCache(object):
     def __init__(self):
+        """UNSAFE"""
         # 36 - 3, because bases 0, 1 make no sense
         # and 2 is handled differently
         self.parts_cache = [None] * 34
@@ -2403,6 +2448,7 @@ class _PartsCache(object):
             self.mindigits[i] = mindigits
 
     def get_cached_parts(self, base):
+        """UNSAFE"""
         index = base - 3
         res = self.parts_cache[index]
         if res is None:
@@ -2413,11 +2459,13 @@ class _PartsCache(object):
         return res
 
     def get_mindigits(self, base):
+        """UNSAFE"""
         return self.mindigits[base - 3]
 
 _parts_cache = _PartsCache()
 
 def _format_int_general(val, digits):
+    """UNSAFE"""
     base = len(digits)
     out = []
     while val:
@@ -2427,10 +2475,12 @@ def _format_int_general(val, digits):
     return "".join(out)
 
 def _format_int10(val, digits):
+    """UNSAFE"""
     return str(val)
 
 @specialize.arg(7)
 def _format_recursive(x, i, output, pts, digits, size_prefix, mindigits, _format_int):
+    """UNSAFE"""
     # bottomed out with min_digit sized pieces
     # use str of ints
     if i < 0:
@@ -2449,6 +2499,7 @@ def _format_recursive(x, i, output, pts, digits, size_prefix, mindigits, _format
         _format_recursive(bot, i-1, output, pts, digits, size_prefix, mindigits, _format_int)
 
 def _format(x, digits, prefix='', suffix=''):
+    """UNSAFE"""
     if x.sign == 0:
         return prefix + "0" + suffix
     base = len(digits)
@@ -2499,7 +2550,7 @@ def _format(x, digits, prefix='', suffix=''):
 
 @specialize.arg(1)
 def _bitwise(a, op, b): # '&', '|', '^'
-    """ Bitwise and/or/xor operations """
+    """UNSAFE Bitwise and/or/xor operations """
 
     if a.sign < 0:
         a = a.invert()
@@ -2582,7 +2633,7 @@ def _bitwise(a, op, b): # '&', '|', '^'
 
 @specialize.arg(1)
 def _int_bitwise(a, op, b): # '&', '|', '^'
-    """ Bitwise and/or/xor operations """
+    """UNSAFE Bitwise and/or/xor operations """
 
     if not int_in_valid_range(b):
         # Fallback to long.
@@ -2668,8 +2719,7 @@ ULONGLONG_BOUND = r_ulonglong(1L << (r_longlong.BITS-1))
 LONGLONG_MIN = r_longlong(-(1L << (r_longlong.BITS-1)))
 
 def _AsLongLong(v):
-    """
-    Get a r_longlong integer from a bigint object.
+    """UNSAFE Get a r_longlong integer from a bigint object.
     Raises OverflowError if overflow occurs.
     """
     x = _AsULonglong_ignore_sign(v)
@@ -2686,6 +2736,7 @@ def _AsLongLong(v):
     return x
 
 def _AsULonglong_ignore_sign(v):
+    """UNSAFE"""
     x = r_ulonglong(0)
     i = v.numdigits() - 1
     while i >= 0:
@@ -2698,7 +2749,9 @@ def _AsULonglong_ignore_sign(v):
     return x
 
 def make_unsigned_mask_conversion(T):
+    """UNSAFE"""
     def _As_unsigned_mask(v):
+        """UNSAFE"""
         x = T(0)
         i = v.numdigits() - 1
         while i >= 0:
@@ -2713,6 +2766,7 @@ _AsULonglong_mask = make_unsigned_mask_conversion(r_ulonglong)
 _AsUInt_mask = make_unsigned_mask_conversion(r_uint)
 
 def _hash(v):
+    """UNSAFE"""
     # This is designed so that Python ints and longs with the
     # same value hash to the same value, otherwise comparisons
     # of mapping keys will turn out weird.  Moreover, purely
@@ -2741,6 +2795,7 @@ def _hash(v):
 # a few internal helpers
 
 def digits_max_for_base(base):
+    """UNSAFE"""
     dec_per_digit = 1
     while base ** dec_per_digit < MASK:
         dec_per_digit += 1
@@ -2752,6 +2807,7 @@ DEC_MAX = digits_max_for_base(10)
 assert DEC_MAX == BASE_MAX[10]
 
 def _decimalstr_to_bigint(s):
+    """UNSAFE"""
     # a string that has been already parsed to be decimal and valid,
     # is turned into a bigint
     p = 0
@@ -2780,6 +2836,7 @@ def _decimalstr_to_bigint(s):
     return a
 
 def parse_digit_string(parser):
+    """UNSAFE"""
     # helper for fromstr
     base = parser.base
     if (base & (base - 1)) == 0:
@@ -2802,6 +2859,7 @@ def parse_digit_string(parser):
     return a
 
 def parse_string_from_binary_base(parser):
+    """UNSAFE"""
     # The point to this routine is that it takes time linear in the number of
     # string characters.
     from rpython.rlib.rstring import ParseStringError

--- a/rpython/rtyper/lltypesystem/rlist.py
+++ b/rpython/rtyper/lltypesystem/rlist.py
@@ -89,7 +89,9 @@ class BaseListRepr(AbstractBaseListRepr):
                                  "ll_items": ll_fixed_items,
                                  "ITEM": ITEM,
                                  "ll_getitem_fast": ll_fixed_getitem_fast,
+                                 "ll_getitem_fast_unsafe": ll_fixed_getitem_fast_unsafe,
                                  "ll_setitem_fast": ll_fixed_setitem_fast,
+                                 "ll_setitem_fast_unsafe": ll_fixed_setitem_fast_unsafe,
                             }))
         return ITEMARRAY
 
@@ -123,7 +125,9 @@ class ListRepr(AbstractListRepr, BaseListRepr):
                                           "ll_items": ll_items,
                                           "ITEM": ITEM,
                                           "ll_getitem_fast": ll_getitem_fast,
+                                          "ll_getitem_fast_unsafe": ll_getitem_fast_unsafe,
                                           "ll_setitem_fast": ll_setitem_fast,
+                                          "ll_setitem_fast_unsafe": ll_setitem_fast_unsafe,
                                           "_ll_resize_ge": _ll_list_resize_ge,
                                           "_ll_resize_le": _ll_list_resize_le,
                                           "_ll_resize": _ll_list_resize,
@@ -374,10 +378,18 @@ def ll_getitem_fast(l, index):
     return l.ll_items()[index]
 ll_getitem_fast.oopspec = 'list.getitem(l, index)'
 
+def ll_getitem_fast_unsafe(l, index):
+    return l.ll_items()[index]
+ll_getitem_fast_unsafe.oopspec = 'list.getitem(l, index)'
+
 def ll_setitem_fast(l, index, item):
     ll_assert(index < l.length, "setitem out of bounds")
     l.ll_items()[index] = item
 ll_setitem_fast.oopspec = 'list.setitem(l, index, item)'
+
+def ll_setitem_fast_unsafe(l, index, item):
+    l.ll_items()[index] = item
+ll_setitem_fast_unsafe.oopspec = 'list.setitem(l, index, item)'
 
 # fixed size versions
 
@@ -404,10 +416,18 @@ def ll_fixed_getitem_fast(l, index):
     return l[index]
 ll_fixed_getitem_fast.oopspec = 'list.getitem(l, index)'
 
+def ll_fixed_getitem_fast_unsafe(l, index):
+    return l[index]
+ll_fixed_getitem_fast_unsafe.oopspec = 'list.getitem(l, index)'
+
 def ll_fixed_setitem_fast(l, index, item):
     ll_assert(index < len(l), "fixed setitem out of bounds")
     l[index] = item
 ll_fixed_setitem_fast.oopspec = 'list.setitem(l, index, item)'
+
+def ll_fixed_setitem_fast_unsafe(l, index, item):
+    l[index] = item
+ll_fixed_setitem_fast_unsafe.oopspec = 'list.setitem(l, index, item)'
 
 def newlist(llops, r_list, items_v, v_sizehint=None):
     LIST = r_list.LIST

--- a/rpython/rtyper/rlist.py
+++ b/rpython/rtyper/rlist.py
@@ -265,7 +265,6 @@ class __extend__(pairtype(AbstractBaseListRepr, Repr)):
 class __extend__(pairtype(AbstractBaseListRepr, IntegerRepr)):
 
     def rtype_getitem((r_lst, r_int), hop, checkidx=False):
-        # ll_assert(hop.unsafe == False, "unsafe is true")
         v_lst, v_index = hop.inputargs(r_lst, Signed)
         if checkidx:
             hop.exception_is_here()
@@ -706,9 +705,6 @@ def ll_pop_nonneg(func, l, index):
 ll_pop_nonneg.oopspec = 'list.pop(l, index)'
 
 def ll_pop_nonneg_unsafe(func, l, index):
-    # if func is dum_checkidx:
-    #     if index >= l.ll_length():
-    #         raise IndexError
     res = l.ll_getitem_fast_unsafe(index)
     ll_delitem_nonneg_unsafe(dum_nocheck, l, index)
     return res
@@ -730,8 +726,6 @@ def ll_pop_default(func, l):
 
 def ll_pop_default_unsafe(func, l):
     length = l.ll_length()
-    # if func is dum_checkidx and (length == 0):
-    #     raise IndexError
     index = length - 1
     newlength = index
     res = l.ll_getitem_fast_unsafe(index)
@@ -763,8 +757,6 @@ ll_pop_zero.oopspec = 'list.pop(l, 0)'
 
 def ll_pop_zero_unsafe(func, l):
     length = l.ll_length()
-    # if func is dum_checkidx and (length == 0):
-    #     raise IndexError
     newlength = length - 1
     res = l.ll_getitem_fast_unsafe(0)
     j = 0
@@ -798,9 +790,6 @@ def ll_pop_unsafe(func, l, index):
     length = l.ll_length()
     if index < 0:
         index += length
-    # if func is dum_checkidx:
-    #     if index < 0 or index >= length:
-    #         raise IndexError
     res = l.ll_getitem_fast_unsafe(index)
     ll_delitem_nonneg_unsafe(dum_nocheck, l, index)
     return res
@@ -839,9 +828,6 @@ ll_getitem_nonneg._always_inline_ = True
 # no oopspec -- the function is inlined by the JIT
 
 def ll_getitem_nonneg_unsafe(func, basegetitem, l, index):
-    # if func is dum_checkidx:
-    #     if index >= l.ll_length():
-    #         raise IndexError
     return basegetitem(l, index)
 ll_getitem_nonneg_unsafe._always_inline_ = True
 # no oopspec -- the function is inlined by the JIT
@@ -867,16 +853,6 @@ def ll_getitem(func, basegetitem, l, index):
 # no oopspec -- the function is inlined by the JIT
 
 def ll_getitem_unsafe(func, basegetitem, l, index):
-    # if func is dum_checkidx:
-    #     length = l.ll_length()    # common case: 0 <= index < length
-    #     if r_uint(index) >= r_uint(length):
-    #         # Failed, so either (-length <= index < 0), or we have to raise
-    #         # IndexError.  First add 'length' to get the final index, then
-    #         # check that we now have (0 <= index < length).
-    #         index = r_uint(index) + r_uint(length)
-    #         if index >= r_uint(length):
-    #             raise IndexError
-    #         index = intmask(index)
     return basegetitem(l, index)
 # no oopspec -- the function is inlined by the JIT
 
@@ -907,9 +883,6 @@ ll_setitem_nonneg._always_inline_ = True
 # no oopspec -- the function is inlined by the JIT
 
 def ll_setitem_nonneg_unsafe(func, l, index, newitem):
-    # if func is dum_checkidx:
-    #     if index >= l.ll_length():
-    #         raise IndexError
     l.ll_setitem_fast_unsafe(index, newitem)
 ll_setitem_nonneg_unsafe._always_inline_ = True
 # no oopspec -- the function is inlined by the JIT
@@ -930,13 +903,6 @@ def ll_setitem(func, l, index, newitem):
 # no oopspec -- the function is inlined by the JIT
 
 def ll_setitem_unsafe(func, l, index, newitem):
-    # if func is dum_checkidx:
-    #     length = l.ll_length()
-    #     if r_uint(index) >= r_uint(length):   # see comments in ll_getitem().
-    #         index = r_uint(index) + r_uint(length)
-    #         if index >= r_uint(length):
-    #             raise IndexError
-    #         index = intmask(index)
     l.ll_setitem_fast_unsafe(index, newitem)
 # no oopspec -- the function is inlined by the JIT
 
@@ -966,9 +932,6 @@ ll_delitem_nonneg.oopspec = 'list.delitem(l, index)'
 @enforceargs(None, None, int)
 def ll_delitem_nonneg_unsafe(func, l, index):
     length = l.ll_length()
-    # if func is dum_checkidx:
-    #     if index >= length:
-    #         raise IndexError
     newlength = length - 1
     j = index
     j1 = j+1
@@ -999,13 +962,6 @@ def ll_delitem(func, l, index):
 # no oopspec -- the function is inlined by the JIT
 
 def ll_delitem_unsafe(func, l, index):
-    # if func is dum_checkidx:
-    #     length = l.ll_length()
-    #     if r_uint(index) >= r_uint(length):   # see comments in ll_getitem().
-    #         index = r_uint(index) + r_uint(length)
-    #         if index >= r_uint(length):
-    #             raise IndexError
-    #         index = intmask(index)
     ll_delitem_nonneg_unsafe(dum_nocheck, l, index)
 # no oopspec -- the function is inlined by the JIT
 

--- a/rpython/rtyper/rtyper.py
+++ b/rpython/rtyper/rtyper.py
@@ -47,7 +47,7 @@ llinterp_backend = LLInterpBackend()
 class RPythonTyper(object):
     from rpython.rtyper.rmodel import log
 
-    def __init__(self, annotator, backend=genc_backend):
+    def __init__(self, annotator, backend=genc_backend, unsafe=False):
         self.annotator = annotator
         self.backend = backend
         self.lowlevel_ann_policy = LowLevelAnnotatorPolicy(self)
@@ -423,13 +423,13 @@ class RPythonTyper(object):
         # enumerate the HighLevelOps in a block.
         if block.operations:
             for op in block.operations[:-1]:
-                yield HighLevelOp(self, op, [], llops)
+                yield HighLevelOp(self, op, [], llops, block.unsafe)
             # look for exception links for the last operation
             if block.canraise:
                 exclinks = block.exits[1:]
             else:
                 exclinks = []
-            yield HighLevelOp(self, block.operations[-1], exclinks, llops)
+            yield HighLevelOp(self, block.operations[-1], exclinks, llops, block.unsafe)
 
     def translate_hl_to_ll(self, hop, varmapping):
         #self.log.translating(hop.spaceop.opname, hop.args_s)
@@ -616,11 +616,12 @@ RPythonTyper._registeroperations(unaryop.UNARY_OPERATIONS, binaryop.BINARY_OPERA
 
 
 class HighLevelOp(object):
-    def __init__(self, rtyper, spaceop, exceptionlinks, llops):
+    def __init__(self, rtyper, spaceop, exceptionlinks, llops, unsafe=False):
         self.rtyper         = rtyper
         self.spaceop        = spaceop
         self.exceptionlinks = exceptionlinks
         self.llops          = llops
+        self.unsafe         = unsafe
 
     def setup(self):
         rtyper = self.rtyper

--- a/rpython/rtyper/test/test_unsafe_rlist.py
+++ b/rpython/rtyper/test/test_unsafe_rlist.py
@@ -1,0 +1,1717 @@
+import sys
+import re
+
+import py
+
+from rpython.rtyper.debug import ll_assert
+from rpython.rtyper.error import TyperError
+from rpython.rtyper.llinterp import LLException, LLAssertFailure
+from rpython.rtyper.lltypesystem import rlist as ll_rlist
+from rpython.rtyper.lltypesystem.rlist import ListRepr, FixedSizeListRepr, ll_newlist, ll_fixed_newlist
+from rpython.rtyper.rint import signed_repr
+from rpython.rtyper.rlist import *
+from rpython.rtyper.test.tool import BaseRtypingTest
+from rpython.translator.translator import TranslationContext
+
+
+# undo the specialization parameters
+for n1 in 'get set del'.split():
+    if n1 == "get":
+        extraarg = "ll_getitem_fast, "
+    else:
+        extraarg = ""
+    for n2 in '', '_nonneg':
+        name = 'll_%sitem%s' % (n1, n2)
+        globals()['_' + name] = globals()[name]
+        exec """if 1:
+            def %s_unsafe(*args):
+                return _%s(dum_checkidx, %s*args)
+""" % (name, name, extraarg)
+del n1, n2, name
+
+
+class BaseTestListImpl:
+
+    def check_list(self, l1, expected):
+        assert ll_len(l1) == len(expected)
+        for i, x in zip(range(len(expected)), expected):
+            assert ll_getitem_nonneg_unsafe(l1, i) == x
+
+    def test_rlist_basic(self):
+        l = self.sample_list()
+        assert ll_getitem_unsafe(l, -4) == 42
+        assert ll_getitem_nonneg_unsafe(l, 1) == 43
+        assert ll_getitem_unsafe(l, 2) == 44
+        assert ll_getitem_unsafe(l, 3) == 45
+        assert ll_len(l) == 4
+        self.check_list(l, [42, 43, 44, 45])
+
+    def test_rlist_set(self):
+        l = self.sample_list()
+        ll_setitem_unsafe(l, -1, 99)
+        self.check_list(l, [42, 43, 44, 99])
+        ll_setitem_nonneg_unsafe(l, 1, 77)
+        self.check_list(l, [42, 77, 44, 99])
+
+    def test_rlist_slice(self):
+        l = self.sample_list()
+        LIST = typeOf(l).TO
+        self.check_list(ll_listslice_startonly(LIST, l, 0), [42, 43, 44, 45])
+        self.check_list(ll_listslice_startonly(LIST, l, 1), [43, 44, 45])
+        self.check_list(ll_listslice_startonly(LIST, l, 2), [44, 45])
+        self.check_list(ll_listslice_startonly(LIST, l, 3), [45])
+        self.check_list(ll_listslice_startonly(LIST, l, 4), [])
+        for start in range(5):
+            for stop in range(start, 8):
+                self.check_list(ll_listslice_startstop(LIST, l, start, stop),
+                                [42, 43, 44, 45][start:stop])
+
+    def test_rlist_setslice(self):
+        n = 100
+        for start in range(5):
+            for stop in range(start, 5):
+                l1 = self.sample_list()
+                l2 = self.sample_list()
+                expected = [42, 43, 44, 45]
+                for i in range(start, stop):
+                    expected[i] = n
+                    ll_setitem_unsafe(l2, i, n)
+                    n += 1
+                l2 = ll_listslice_startstop(typeOf(l2).TO, l2, start, stop)
+                ll_listsetslice(l1, start, stop, l2)
+                self.check_list(l1, expected)
+
+
+# helper used by some tests below
+def list_is_clear(lis, idx):
+    items = lis._obj.items._obj.items
+    for i in range(idx, len(items)):
+        if items[i]._obj is not None:
+            return False
+    return True
+
+
+class TestListImpl(BaseTestListImpl):
+    def sample_list(self):    # [42, 43, 44, 45]
+        rlist = ListRepr(None, signed_repr)
+        rlist.setup()
+        l = ll_newlist(rlist.lowleveltype.TO, 3)
+        ll_setitem_unsafe(l, 0, 42)
+        ll_setitem_unsafe(l, -2, 43)
+        ll_setitem_nonneg_unsafe(l, 2, 44)
+        ll_append(l, 45)
+        return l
+
+    def test_rlist_del(self):
+        l = self.sample_list()
+        ll_delitem_nonneg_unsafe(l, 0)
+        self.check_list(l, [43, 44, 45])
+        ll_delitem_unsafe(l, -2)
+        self.check_list(l, [43, 45])
+        ll_delitem_unsafe(l, 1)
+        self.check_list(l, [43])
+        ll_delitem_unsafe(l, 0)
+        self.check_list(l, [])
+
+    def test_rlist_extend_concat(self):
+        l = self.sample_list()
+        ll_extend(l, l)
+        self.check_list(l, [42, 43, 44, 45] * 2)
+        l1 = ll_concat(typeOf(l).TO, l, l)
+        assert typeOf(l1) == typeOf(l)
+        assert l1 != l
+        self.check_list(l1, [42, 43, 44, 45] * 4)
+
+    def test_rlist_delslice(self):
+        l = self.sample_list()
+        ll_listdelslice_startonly(l, 3)
+        self.check_list(l, [42, 43, 44])
+        ll_listdelslice_startonly(l, 0)
+        self.check_list(l, [])
+        for start in range(5):
+            for stop in range(start, 8):
+                l = self.sample_list()
+                ll_listdelslice_startstop(l, start, stop)
+                expected = [42, 43, 44, 45]
+                del expected[start:stop]
+                self.check_list(l, expected)
+
+
+class TestFixedSizeListImpl(BaseTestListImpl):
+    def sample_list(self):    # [42, 43, 44, 45]
+        rlist = FixedSizeListRepr(None, signed_repr)
+        rlist.setup()
+        l = ll_fixed_newlist(rlist.lowleveltype.TO, 4)
+        ll_setitem_unsafe(l, 0, 42)
+        ll_setitem_unsafe(l, -3, 43)
+        ll_setitem_nonneg_unsafe(l, 2, 44)
+        ll_setitem_unsafe(l, 3, 45)
+        return l
+
+    def test_rlist_extend_concat(self):
+        l = self.sample_list()
+        lvar = TestListImpl.sample_list(TestListImpl())
+        ll_extend(lvar, l)
+        self.check_list(lvar, [42, 43, 44, 45] * 2)
+
+        l1 = ll_concat(typeOf(l).TO, lvar, l)
+        assert typeOf(l1) == typeOf(l)
+        assert l1 != l
+        self.check_list(l1, [42, 43, 44, 45] * 3)
+
+        l1 = ll_concat(typeOf(l).TO, l, lvar)
+        assert typeOf(l1) == typeOf(l)
+        assert l1 != l
+        self.check_list(l1, [42, 43, 44, 45] * 3)
+
+        lvar1 = ll_concat(typeOf(lvar).TO, lvar, l)
+        assert typeOf(lvar1) == typeOf(lvar)
+        assert lvar1 != lvar
+        self.check_list(l1, [42, 43, 44, 45] * 3)
+
+        lvar1 = ll_concat(typeOf(lvar).TO, l, lvar)
+        assert typeOf(lvar1) == typeOf(lvar)
+        assert lvar1 != lvar
+        self.check_list(lvar1, [42, 43, 44, 45] * 3)
+
+
+
+# ____________________________________________________________
+
+# these classes are used in the tests below
+class Foo:
+    pass
+
+class Bar(Foo):
+    pass
+
+class Freezing:
+    def _freeze_(self):
+        return True
+
+
+class TestRlist(BaseRtypingTest):
+    rlist = ll_rlist
+
+    def test_simple(self):
+        def dummyfn():
+            l = [10, 20, 30]
+            return l[2]
+        res = self.interpret(dummyfn, [])
+        assert res == 30
+
+    def test_append(self):
+        def dummyfn():
+            l = []
+            l.append(50)
+            l.append(60)
+            l.append(70)
+            l.append(80)
+            l.append(90)
+            return len(l), l[0], l[-1]
+        res = self.interpret(dummyfn, [])
+        assert res.item0 == 5
+        assert res.item1 == 50
+        assert res.item2 == 90
+
+    def test_len(self):
+        def dummyfn():
+            l = [5, 10]
+            return len(l)
+        res = self.interpret(dummyfn, [])
+        assert res == 2
+
+        def dummyfn():
+            l = [5]
+            l.append(6)
+            return len(l)
+        res = self.interpret(dummyfn, [])
+        assert res == 2
+
+    def test_iterate(self):
+        def dummyfn():
+            total = 0
+            for x in [1, 3, 5, 7, 9]:
+                total += x
+            return total
+        res = self.interpret(dummyfn, [])
+        assert res == 25
+        def dummyfn():
+            total = 0
+            l = [1, 3, 5, 7]
+            l.append(9)
+            for x in l:
+                total += x
+            return total
+        res = self.interpret(dummyfn, [])
+        assert res == 25
+
+    def test_iterate_next(self):
+        def dummyfn():
+            total = 0
+            it = iter([1, 3, 5, 7, 9])
+            while 1:
+                try:
+                    x = it.next()
+                except StopIteration:
+                    break
+                total += x
+            return total
+        res = self.interpret(dummyfn, [])
+        assert res == 25
+        def dummyfn():
+            total = 0
+            l = [1, 3, 5, 7]
+            l.append(9)
+            it = iter(l)
+            while 1:
+                try:
+                    x = it.next()
+                except StopIteration:
+                    break
+                total += x
+            return total
+        res = self.interpret(dummyfn, [])
+        assert res == 25
+
+    def test_recursive(self):
+        def dummyfn(N):
+            l = []
+            while N > 0:
+                l = [l]
+                N -= 1
+            return len(l)
+        res = self.interpret(dummyfn, [5])
+        assert res == 1
+
+        def dummyfn(N):
+            l = []
+            while N > 0:
+                l.append(l)
+                N -= 1
+            return len(l)
+        res = self.interpret(dummyfn, [5])
+        assert res == 5
+
+    def test_add(self):
+        def dummyfn():
+            l = [5]
+            l += [6, 7]
+            return l + [8]
+        res = self.interpret(dummyfn, [])
+        assert self.ll_to_list(res) == [5, 6, 7, 8]
+
+        def dummyfn():
+            l = [5]
+            l += [6, 7]
+            l2 =  l + [8]
+            l2.append(9)
+            return l2
+        res = self.interpret(dummyfn, [])
+        assert self.ll_to_list(res) == [5, 6, 7, 8, 9]
+
+    def test_slice(self):
+        def dummyfn():
+            l = [5, 6, 7, 8, 9]
+            return l[:2], l[1:4], l[3:]
+        res = self.interpret(dummyfn, [])
+        assert self.ll_to_list(res.item0) == [5, 6]
+        assert self.ll_to_list(res.item1) == [6, 7, 8]
+        assert self.ll_to_list(res.item2) == [8, 9]
+
+        def dummyfn():
+            l = [5, 6, 7, 8]
+            l.append(9)
+            return l[:2], l[1:4], l[3:]
+        res = self.interpret(dummyfn, [])
+        assert self.ll_to_list(res.item0) == [5, 6]
+        assert self.ll_to_list(res.item1) == [6, 7, 8]
+        assert self.ll_to_list(res.item2) == [8, 9]
+
+    def test_getslice_not_constant_folded(self):
+        l = list('abcdef')
+
+        def dummyfn():
+            result = []
+            for i in range(3):
+                l2 = l[2:]
+                result.append(l2.pop())
+            return result
+
+        res = self.interpret(dummyfn, [])
+        assert self.ll_to_list(res) == ['f', 'f', 'f']
+
+    def test_set_del_item(self):
+        def dummyfn():
+            l = [5, 6, 7]
+            l[1] = 55
+            l[-1] = 66
+            return l
+        res = self.interpret(dummyfn, [])
+        assert self.ll_to_list(res) == [5, 55, 66]
+
+        def dummyfn():
+            l = []
+            l.append(5)
+            l.append(6)
+            l.append(7)
+            l[1] = 55
+            l[-1] = 66
+            return l
+        res = self.interpret(dummyfn, [])
+        assert self.ll_to_list(res) == [5, 55, 66]
+
+        def dummyfn():
+            l = [5, 6, 7]
+            l[1] = 55
+            l[-1] = 66
+            del l[0]
+            del l[-1]
+            del l[:]
+            return len(l)
+        res = self.interpret(dummyfn, [])
+        assert res == 0
+
+    def test_setslice(self):
+        def dummyfn():
+            l = [10, 9, 8, 7]
+            l[:2] = [6, 5]
+            return l[0], l[1], l[2], l[3]
+        res = self.interpret(dummyfn, ())
+        assert res.item0 == 6
+        assert res.item1 == 5
+        assert res.item2 == 8
+        assert res.item3 == 7
+
+        def dummyfn():
+            l = [10, 9, 8]
+            l.append(7)
+            l[:2] = [6, 5]
+            return l[0], l[1], l[2], l[3]
+        res = self.interpret(dummyfn, ())
+        assert res.item0 == 6
+        assert res.item1 == 5
+        assert res.item2 == 8
+        assert res.item3 == 7
+
+        def dummyfn():
+            l = [10, 9, 8, 7]
+            l[1:3] = [42]
+            return l[0], l[1], l[2]
+        res = self.interpret(dummyfn, ())
+        assert res.item0 == 10
+        assert res.item1 == 42
+        assert res.item2 == 7
+
+        def dummyfn():
+            l = [10, 9, 8, 7]
+            l[1:3] = [6, 5, 0]
+            return l[0], l[1], l[2], l[3], l[4]
+        res = self.interpret(dummyfn, ())
+        assert res.item0 == 10
+        assert res.item1 == 6
+        assert res.item2 == 5
+        assert res.item3 == 0
+        assert res.item4 == 7
+
+        def dummyfn():
+            l = [10, 9, 8, 7]
+            l[1:1] = [6, 5, 0]
+            return l[0], l[1], l[2], l[3], l[4], l[5], l[6]
+        res = self.interpret(dummyfn, ())
+        assert res.item0 == 10
+        assert res.item1 == 6
+        assert res.item2 == 5
+        assert res.item3 == 0
+        assert res.item4 == 9
+        assert res.item5 == 8
+        assert res.item6 == 7
+
+        def dummyfn():
+            l = [10, 9, 8, 7]
+            l[1:3] = []
+            return l[0], l[1]
+        res = self.interpret(dummyfn, ())
+        assert res.item0 == 10
+        assert res.item1 == 7
+
+    def test_delslice(self):
+        def dummyfn():
+            l = [10, 9, 8, 7]
+            del l[:2]
+            return len(l), l[0], l[1]
+        res = self.interpret(dummyfn, ())
+        assert res.item0 == 2
+        assert res.item1 == 8
+        assert res.item2 == 7
+
+        def dummyfn():
+            l = [10, 9, 8, 7]
+            del l[2:]
+            return len(l), l[0], l[1]
+        res = self.interpret(dummyfn, ())
+        assert res.item0 == 2
+        assert res.item1 == 10
+        assert res.item2 == 9
+
+    def test_bltn_list(self):
+        # test for ll_copy()
+        for resize1 in [False, True]:
+            for resize2 in [False, True]:
+                def dummyfn():
+                    l1 = [42]
+                    if resize1:
+                        l1.append(43)
+                    l2 = list(l1)
+                    if resize2:
+                        l2.append(44)
+                    l2[0] = 0
+                    return l1[0]
+                res = self.interpret(dummyfn, ())
+                assert res == 42
+
+    def test_bltn_list_from_string(self):
+        def dummyfn(n):
+            l1 = list(str(n))
+            return ord(l1[0])
+        res = self.interpret(dummyfn, [71234])
+        assert res == ord('7')
+
+    def test_bltn_list_from_unicode(self):
+        def dummyfn(n):
+            l1 = list(unicode(str(n)))
+            return ord(l1[0])
+        res = self.interpret(dummyfn, [71234])
+        assert res == ord('7')
+
+    def test_bltn_list_from_string_resize(self):
+        def dummyfn(n):
+            l1 = list(str(n))
+            l1.append('X')
+            return ord(l1[0])
+        res = self.interpret(dummyfn, [71234])
+        assert res == ord('7')
+
+    def test_bltn_list_from_unicode_resize(self):
+        def dummyfn(n):
+            l1 = list(unicode(str(n)))
+            l1.append(u'X')
+            return ord(l1[0])
+        res = self.interpret(dummyfn, [71234])
+        assert res == ord('7')
+
+    def test_is_true(self):
+        def is_true(lst):
+            if lst:
+                return True
+            else:
+                return False
+        def dummyfn1():
+            return is_true(None)
+        def dummyfn2():
+            return is_true([])
+        def dummyfn3():
+            return is_true([0])
+        assert self.interpret(dummyfn1, ()) == False
+        assert self.interpret(dummyfn2, ()) == False
+        assert self.interpret(dummyfn3, ()) == True
+
+    def test_list_index_simple(self):
+        def dummyfn(i):
+            l = [5, 6, 7, 8]
+            return l.index(i)
+
+        res = self.interpret(dummyfn, (6,))
+        assert res == 1
+        self.interpret_raises(ValueError, dummyfn, [42])
+
+    def test_insert_pop(self):
+        def dummyfn():
+            l = [6, 7, 8]
+            l.insert(0, 5)
+            l.insert(1, 42)
+            l.pop(2)
+            l.pop(0)
+            l.pop(-1)
+            l.pop()
+            return l[-1]
+        res = self.interpret(dummyfn, ())
+        assert res == 42
+
+    def test_insert_bug(self):
+        def dummyfn(n):
+            l = [1]
+            l = l[:]
+            l.pop(0)
+            if n < 0:
+                l.insert(0, 42)
+            else:
+                l.insert(n, 42)
+            return l
+        res = self.interpret(dummyfn, [0])
+        assert res.ll_length() == 1
+        assert res.ll_getitem_fast_unsafe(0) == 42
+        res = self.interpret(dummyfn, [-1])
+        assert res.ll_length() == 1
+        assert res.ll_getitem_fast_unsafe(0) == 42
+
+    def test_inst_pop(self):
+        class A:
+            pass
+        l = [A(), A()]
+        def f(idx):
+            try:
+                return l.pop(idx)
+            except IndexError:
+                return None
+        res = self.interpret(f, [1])
+        assert self.class_name(res) == 'A'
+        #''.join(res.super.typeptr.name) == 'A\00'
+
+    def test_reverse(self):
+        def dummyfn():
+            l = [5, 3, 2]
+            l.reverse()
+            return l[0]*100 + l[1]*10 + l[2]
+        res = self.interpret(dummyfn, ())
+        assert res == 235
+
+        def dummyfn():
+            l = [5]
+            l.append(3)
+            l.append(2)
+            l.reverse()
+            return l[0]*100 + l[1]*10 + l[2]
+        res = self.interpret(dummyfn, ())
+        assert res == 235
+
+    def test_reversed(self):
+        klist = [1, 2, 3]
+
+        def fn():
+            res = []
+            for elem in reversed(klist):
+                res.append(elem)
+            return res[0] * 100 + res[1] * 10 + res[2]
+        res = self.interpret(fn, [])
+        assert res == fn()
+
+    def test_prebuilt_list(self):
+        klist = [6, 7, 8, 9]
+        def dummyfn(n):
+            return klist[n]
+        res = self.interpret(dummyfn, [0])
+        assert res == 6
+        res = self.interpret(dummyfn, [3])
+        assert res == 9
+        res = self.interpret(dummyfn, [-2])
+        assert res == 8
+
+        klist = ['a', 'd', 'z']
+        def mkdummyfn():
+            def dummyfn(n):
+                klist.append('k')
+                return klist[n]
+            return dummyfn
+        res = self.interpret(mkdummyfn(), [0])
+        assert res == 'a'
+        res = self.interpret(mkdummyfn(), [3])
+        assert res == 'k'
+        res = self.interpret(mkdummyfn(), [-2])
+        assert res == 'z'
+
+    def test_bound_list_method(self):
+        klist = [1, 2, 3]
+        # for testing constant methods without actually mutating the constant
+        def dummyfn(n):
+            klist.extend([])
+        self.interpret(dummyfn, [7])
+
+    def test_list_is(self):
+        def dummyfn():
+            l1 = []
+            return l1 is l1
+        res = self.interpret(dummyfn, [])
+        assert res is True
+        def dummyfn():
+            l2 = [1, 2]
+            return l2 is l2
+        res = self.interpret(dummyfn, [])
+        assert res is True
+        def dummyfn():
+            l1 = [2]
+            l2 = [1, 2]
+            return l1 is l2
+        res = self.interpret(dummyfn, [])
+        assert res is False
+        def dummyfn():
+            l1 = [1, 2]
+            l2 = [1]
+            l2.append(2)
+            return l1 is l2
+        res = self.interpret(dummyfn, [])
+        assert res is False
+
+        def dummyfn():
+            l1 = None
+            l2 = [1, 2]
+            return l1 is l2
+        res = self.interpret(dummyfn, [])
+        assert res is False
+
+        def dummyfn():
+            l1 = None
+            l2 = [1]
+            l2.append(2)
+            return l1 is l2
+        res = self.interpret(dummyfn, [])
+        assert res is False
+
+    def test_list_compare(self):
+        def fn(i, j, neg=False):
+            s1 = [[1, 2, 3], [4, 5, 1], None]
+            s2 = [[1, 2, 3], [4, 5, 1], [1], [1, 2], [4, 5, 1, 6],
+                  [7, 1, 1, 8, 9, 10], None]
+            if neg: return s1[i] != s2[i]
+            return s1[i] == s2[j]
+        for i in range(3):
+            for j in range(7):
+                for case in False, True:
+                    res = self.interpret(fn, [i,j,case])
+                    assert res is fn(i, j, case)
+
+        def fn(i, j, neg=False):
+            s1 = [[1, 2, 3], [4, 5, 1], None]
+            l = []
+            l.extend([1,2,3])
+            s2 = [l, [4, 5, 1], [1], [1, 2], [4, 5, 1, 6],
+                  [7, 1, 1, 8, 9, 10], None]
+            if neg: return s1[i] != s2[i]
+            return s1[i] == s2[j]
+        for i in range(3):
+            for j in range(7):
+                for case in False, True:
+                    res = self.interpret(fn, [i,j,case])
+                    assert res is fn(i, j, case)
+
+
+    def test_list_comparestr(self):
+        def fn(i, j, neg=False):
+            s1 = [["hell"], ["hello", "world"]]
+            s1[0][0] += "o" # ensure no interning
+            s2 = [["hello"], ["world"]]
+            if neg: return s1[i] != s2[i]
+            return s1[i] == s2[j]
+        for i in range(2):
+            for j in range(2):
+                for case in False, True:
+                    res = self.interpret(fn, [i,j,case])
+                    assert res is fn(i, j, case)
+
+    def test_list_compare_char_str(self):
+        def fn(i, j):
+            l1 = [str(i)]
+            l2 = [chr(j)]
+            return l1 == l2
+        res = self.interpret(fn, [65, 65])
+        assert res is False
+        res = self.interpret(fn, [1, 49])
+        assert res is True
+
+
+    def test_list_compareinst(self):
+        def fn(i, j, neg=False):
+            foo1 = Foo()
+            foo2 = Foo()
+            bar1 = Bar()
+            s1 = [[foo1], [foo2], [bar1]]
+            s2 = s1[:]
+            if neg: return s1[i] != s2[i]
+            return s1[i] == s2[j]
+        for i in range(3):
+            for j in range(3):
+                for case in False, True:
+                    res = self.interpret(fn, [i, j, case])
+                    assert res is fn(i, j, case)
+
+        def fn(i, j, neg=False):
+            foo1 = Foo()
+            foo2 = Foo()
+            bar1 = Bar()
+            s1 = [[foo1], [foo2], [bar1]]
+            s2 = s1[:]
+
+            s2[0].extend([])
+
+            if neg: return s1[i] != s2[i]
+            return s1[i] == s2[j]
+        for i in range(3):
+            for j in range(3):
+                for case in False, True:
+                    res = self.interpret(fn, [i, j, case])
+                    assert res is fn(i, j, case)
+
+
+    def test_list_contains(self):
+        def fn(i, neg=False):
+            foo1 = Foo()
+            foo2 = Foo()
+            bar1 = Bar()
+            bar2 = Bar()
+            lis = [foo1, foo2, bar1]
+            args = lis + [bar2]
+            if neg : return args[i] not in lis
+            return args[i] in lis
+        for i in range(4):
+            for case in False, True:
+                res = self.interpret(fn, [i, case])
+                assert res is fn(i, case)
+
+        def fn(i, neg=False):
+            foo1 = Foo()
+            foo2 = Foo()
+            bar1 = Bar()
+            bar2 = Bar()
+            lis = [foo1, foo2, bar1]
+            lis.append(lis.pop())
+            args = lis + [bar2]
+            if neg : return args[i] not in lis
+            return args[i] in lis
+        for i in range(4):
+            for case in False, True:
+                res = self.interpret(fn, [i, case])
+                assert res is fn(i, case)
+
+    def test_constant_list_contains(self):
+        # a 'contains' operation on list containing only annotation-time
+        # constants should be optimized into the equivalent code of
+        # 'in prebuilt-dictionary'.  Hard to test directly...
+        def g():
+            return 16
+        def f(i):
+            return i in [1, 2, 4, 8, g()]
+        res = self.interpret(f, [2])
+        assert res is True
+        res = self.interpret(f, [15])
+        assert res is False
+        res = self.interpret(f, [16])
+        assert res is True
+
+    def test_nonconstant_list_contains(self):
+        def f(i):
+            return i in [1, -i, 2, 4, 8]
+        res = self.interpret(f, [2])
+        assert res is True
+        res = self.interpret(f, [15])
+        assert res is False
+        res = self.interpret(f, [0])
+        assert res is True
+
+
+    def test_not_a_char_list_after_all_1(self):
+        def fn(n):
+            l = ['h', 'e', 'l', 'l', '0']
+            return str(n) in l     # turns into: str(n) in {'h','e','l','0'}
+        res = self.interpret(fn, [5])
+        assert res is False
+        res = self.interpret(fn, [0])
+        assert res is True
+
+        def fn():
+            l = ['h', 'e', 'l', 'l', '0']
+            return 'hi' in l     # turns into: 'hi' in {'h','e','l','0'}
+        res = self.interpret(fn, [])
+        assert res is False
+
+    def test_not_a_char_list_after_all_2(self):
+        def fn(n):
+            l = ['h', 'e', 'l', 'l', 'o', chr(n)]
+            return 'world' in l
+        res = self.interpret(fn, [0])
+        assert res is False
+
+    def test_list_index(self):
+        def fn(i):
+            foo1 = Foo()
+            foo2 = Foo()
+            bar1 = Bar()
+            bar2 = Bar()
+            lis = [foo1, foo2, bar1]
+            args = lis + [bar2]
+            return lis.index(args[i])
+        for i in range(4):
+            for varsize in False, True:
+                try:
+                    res2 = fn(i)
+                    res1 = self.interpret(fn, [i])
+                    assert res1 == res2
+                except Exception as e:
+                    self.interpret_raises(e.__class__, fn, [i])
+
+        def fn(i):
+            foo1 = Foo()
+            foo2 = Foo()
+            bar1 = Bar()
+            bar2 = Bar()
+            lis = [foo1, foo2, bar1]
+            args = lis + [bar2]
+            lis.append(lis.pop())
+            return lis.index(args[i])
+        for i in range(4):
+            for varsize in False, True:
+                try:
+                    res2 = fn(i)
+                    res1 = self.interpret(fn, [i])
+                    assert res1 == res2
+                except Exception as e:
+                    self.interpret_raises(e.__class__, fn, [i])
+
+
+    def test_list_str(self):
+        def fn():
+            return str([1,2,3])
+
+        res = self.interpret(fn, [])
+        assert self.ll_to_string(res) == fn()
+
+        def fn():
+            return str([[1,2,3]])
+
+        res = self.interpret(fn, [])
+        assert self.ll_to_string(res) == fn()
+
+        def fn():
+            l = [1,2]
+            l.append(3)
+            return str(l)
+
+        res = self.interpret(fn, [])
+        assert self.ll_to_string(res) == fn()
+
+        def fn():
+            l = [1,2]
+            l.append(3)
+            return str([l])
+
+        res = self.interpret(fn, [])
+        assert self.ll_to_string(res) == fn()
+
+        def fn():
+            return str([])
+
+        res = self.interpret(fn, [])
+        assert self.ll_to_string(res) == fn()
+
+        def fn():
+            return str([1.25])
+
+        res = self.interpret(fn, [])
+        assert eval(self.ll_to_string(res)) == [1.25]
+
+    def test_list_or_None(self):
+        empty_list = []
+        nonempty_list = [1, 2]
+        def fn(i):
+            test = [None, empty_list, nonempty_list][i]
+            if test:
+                return 1
+            else:
+                return 0
+
+        res = self.interpret(fn, [0])
+        assert res == 0
+        res = self.interpret(fn, [1])
+        assert res == 0
+        res = self.interpret(fn, [2])
+        assert res == 1
+
+
+        nonempty_list = [1, 2]
+        def fn(i):
+            empty_list = [1]
+            empty_list.pop()
+            nonempty_list = []
+            nonempty_list.extend([1,2])
+            test = [None, empty_list, nonempty_list][i]
+            if test:
+                return 1
+            else:
+                return 0
+
+        res = self.interpret(fn, [0])
+        assert res == 0
+        res = self.interpret(fn, [1])
+        assert res == 0
+        res = self.interpret(fn, [2])
+        assert res == 1
+
+
+    def test_inst_list(self):
+        def fn():
+            l = [None]
+            l[0] = Foo()
+            l.append(Bar())
+            l2 = [l[1], l[0], l[0]]
+            l.extend(l2)
+            for x in l2:
+                l.append(x)
+            x = l.pop()
+            x = l.pop()
+            x = l.pop()
+            x = l2.pop()
+            return str(x)+";"+str(l)
+        res = self.ll_to_string(self.interpret(fn, []))
+        res = res.replace('rpython.rtyper.test.test_rlist.', '')
+        res = re.sub(' at 0x[a-z0-9]+', '', res)
+        assert res == '<Foo object>;[<Foo object>, <Bar object>, <Bar object>, <Foo object>, <Foo object>]'
+
+        def fn():
+            l = [None] * 2
+            l[0] = Foo()
+            l[1] = Bar()
+            l2 = [l[1], l[0], l[0]]
+            l = l + [None] * 3
+            i = 2
+            for x in l2:
+                l[i] = x
+                i += 1
+            return str(l)
+        res = self.ll_to_string(self.interpret(fn, []))
+        res = res.replace('rpython.rtyper.test.test_rlist.', '')
+        res = re.sub(' at 0x[a-z0-9]+', '', res)
+        assert res == '[<Foo object>, <Bar object>, <Bar object>, <Foo object>, <Foo object>]'
+
+    def test_list_slice_minusone(self):
+        def fn(i):
+            lst = [i, i+1, i+2]
+            lst2 = lst[:-1]
+            return lst[-1] * lst2[-1]
+        res = self.interpret(fn, [5])
+        assert res == 42
+
+        def fn(i):
+            lst = [i, i+1, i+2, 7]
+            lst.pop()
+            lst2 = lst[:-1]
+            return lst[-1] * lst2[-1]
+        res = self.interpret(fn, [5])
+        assert res == 42
+
+    def test_list_multiply(self):
+        def fn(i):
+            lst = [i] * i
+            ret = len(lst)
+            if ret:
+                ret *= lst[-1]
+            return ret
+        for arg in (1, 9, 0, -1, -27):
+            res = self.interpret(fn, [arg])
+            assert res == fn(arg)
+        def fn(i):
+            lst = [i, i + 1] * i
+            ret = len(lst)
+            if ret:
+                ret *= lst[-1]
+            return ret
+        for arg in (1, 9, 0, -1, -27):
+            res = self.interpret(fn, [arg])
+            assert res == fn(arg)
+        def fn(i):
+            lst =  i * [i, i + 1]
+            ret = len(lst)
+            if ret:
+                ret *= lst[-1]
+            return ret
+        for arg in (1, 9, 0, -1, -27):
+            res = self.interpret(fn, [arg])
+            assert res == fn(arg)
+
+    def test_list_inplace_multiply(self):
+        def fn(i):
+            lst = [i]
+            lst *= i
+            ret = len(lst)
+            if ret:
+                ret *= lst[-1]
+            return ret
+        for arg in (1, 9, 0, -1, -27):
+            res = self.interpret(fn, [arg])
+            assert res == fn(arg)
+        def fn(i):
+            lst = [i, i + 1]
+            lst *= i
+            ret = len(lst)
+            if ret:
+                ret *= lst[-1]
+            return ret
+        for arg in (1, 9, 0, -1, -27):
+            res = self.interpret(fn, [arg])
+            assert res == fn(arg)
+
+    def test_indexerror(self):
+        def fn(i):
+            l = [5, 8, 3]
+            try:
+                l[i] = 99
+            except IndexError:
+                pass
+            try:
+                del l[i]
+            except IndexError:
+                pass
+            try:
+                return l[2]
+            except IndexError:
+                return -1
+        res = self.interpret(fn, [6])
+        assert res == 3
+        res = self.interpret(fn, [-2])
+        assert res == -1
+
+        def fn(i):
+            l = [5, 8]
+            l.append(3)
+            try:
+                l[i] = 99
+            except IndexError:
+                pass
+            try:
+                del l[i]
+            except IndexError:
+                pass
+            try:
+                return l[2]
+            except IndexError:
+                return -1
+        res = self.interpret(fn, [6])
+        assert res == 3
+        res = self.interpret(fn, [-2])
+        assert res == -1
+
+    def test_list_basic_ops(self):
+        def list_basic_ops(i=int, j=int):
+            l = [1,2,3]
+            l.insert(0, 42)
+            del l[1]
+            l.append(i)
+            listlen = len(l)
+            l.extend(l)
+            del l[listlen:]
+            l += [5,6]
+            l[1] = i
+            return l[j]
+        for i in range(6):
+            for j in range(6):
+                res = self.interpret(list_basic_ops, [i, j])
+                assert res == list_basic_ops(i, j)
+
+    def test_valueerror(self):
+        def fn(i):
+            l = [4, 7, 3]
+            try:
+                j = l.index(i)
+            except ValueError:
+                j = 100
+            return j
+        res = self.interpret(fn, [4])
+        assert res == 0
+        res = self.interpret(fn, [7])
+        assert res == 1
+        res = self.interpret(fn, [3])
+        assert res == 2
+        res = self.interpret(fn, [6])
+        assert res == 100
+
+        def fn(i):
+            l = [5, 8]
+            l.append(3)
+            try:
+                l[i] = 99
+            except IndexError:
+                pass
+            try:
+                del l[i]
+            except IndexError:
+                pass
+            try:
+                return l[2]
+            except IndexError:
+                return -1
+        res = self.interpret(fn, [6])
+        assert res == 3
+        res = self.interpret(fn, [-2])
+        assert res == -1
+
+    def test_voidlist_prebuilt(self):
+        frlist = [Freezing()] * 17
+        def mylength(l):
+            return len(l)
+        def f():
+            return mylength(frlist)
+        res = self.interpret(f, [])
+        assert res == 17
+
+    def test_voidlist_fixed(self):
+        fr = Freezing()
+        def f():
+            return len([fr, fr])
+        res = self.interpret(f, [])
+        assert res == 2
+
+    def test_voidlist_nonfixed(self):
+        class Freezing:
+            def _freeze_(self):
+                return True
+        fr = Freezing()
+        def f():
+            lst = [fr, fr]
+            lst.append(fr)
+            del lst[1]
+            assert lst[0] is fr
+            return len(lst)
+        res = self.interpret(f, [])
+        assert res == 2
+
+    def test_access_in_try(self):
+        def f(sq):
+            try:
+                return sq[2]
+            except ZeroDivisionError:
+                return 42
+            return -1
+        def g(n):
+            l = [1] * n
+            return f(l)
+        res = self.interpret(g, [3])
+        assert res == 1
+
+    def test_access_in_try_set(self):
+        def f(sq):
+            try:
+                sq[2] = 77
+            except ZeroDivisionError:
+                return 42
+            return -1
+        def g(n):
+            l = [1] * n
+            f(l)
+            return l[2]
+        res = self.interpret(g, [3])
+        assert res == 77
+
+    def test_list_equality(self):
+        def dummyfn(n):
+            lst = [12] * n
+            assert lst == [12, 12, 12]
+            lst2 = [[12, 34], [5], [], [12, 12, 12], [5]]
+            assert lst in lst2
+        self.interpret(dummyfn, [3])
+
+    def test_list_remove(self):
+        def dummyfn(n, p):
+            l = range(n)
+            l.remove(p)
+            return len(l)
+        res = self.interpret(dummyfn, [1, 0])
+        assert res == 0
+
+
+    def test_getitem_exc_1(self):
+        def f(x):
+            l = [1]
+            return l[x]
+
+        res = self.interpret(f, [0])
+        assert res == 1
+        with py.test.raises(LLAssertFailure):
+            self.interpret(f, [1])
+
+        def f(x):
+            l = [1]
+            try:
+                return l[x]
+            except IndexError:
+                return -1
+            except Exception:
+                return 0
+
+        res = self.interpret(f, [0])
+        assert res == 1
+        res = self.interpret(f, [1])
+        assert res == -1
+
+        def f(x):
+            l = [1]
+            try:
+                return l[x]
+            except Exception:
+                return 0
+
+        res = self.interpret(f, [0])
+        assert res == 1
+        res = self.interpret(f, [1])
+        assert res == 0
+
+        def f(x):
+            l = [1]
+            try:
+                return l[x]
+            except ValueError:
+                return 0
+
+        res = self.interpret(f, [0])
+        assert res == 1
+
+    def test_getitem_exc_2(self):
+        def f(x):
+            l = [1]
+            return l[x]
+
+        res = self.interpret(f, [0])
+        assert res == 1
+        with py.test.raises(LLAssertFailure):
+            self.interpret(f, [1])
+
+        def f(x):
+            l = [1]
+            try:
+                return l[x]
+            except IndexError:
+                return -1
+            except Exception:
+                return 0
+
+        res = self.interpret(f, [0])
+        assert res == 1
+        res = self.interpret(f, [1])
+        assert res == -1
+
+        def f(x):
+            l = [1]
+            try:
+                return l[x]
+            except Exception:
+                return 0
+
+        res = self.interpret(f, [0])
+        assert res == 1
+        res = self.interpret(f, [1])
+        assert res == 0
+
+        def f(x):
+            l = [1]
+            try:
+                return l[x]
+            except ValueError:
+                return 0
+
+        res = self.interpret(f, [0])
+        assert res == 1
+        with py.test.raises(LLAssertFailure):
+            self.interpret(f, [1])
+
+    def test_charlist_extension_1(self):
+        def f(n):
+            s = 'hello%d' % n
+            l = ['a', 'b']
+            l += s
+            return ''.join(l)
+        res = self.interpret(f, [58])
+        assert self.ll_to_string(res) == 'abhello58'
+
+    def test_unicharlist_extension_1(self):
+        def f(n):
+            s = 'hello%d' % n
+            l = [u'a', u'b']
+            l += s
+            return ''.join([chr(ord(c)) for c in l])
+        res = self.interpret(f, [58])
+        assert self.ll_to_string(res) == 'abhello58'
+
+    def test_extend_a_non_char_list_1(self):
+        def f(n):
+            s = 'hello%d' % n
+            l = ['foo', 'bar']
+            l += s          # NOT SUPPORTED for now if l is not a list of chars
+            return ''.join(l)
+        py.test.raises(TyperError, self.interpret, f, [58])
+
+    def test_charlist_extension_2(self):
+        def f(n, i):
+            s = 'hello%d' % n
+            assert 0 <= i <= len(s)
+            l = ['a', 'b']
+            l += s[i:]
+            return ''.join(l)
+        res = self.interpret(f, [9381701, 3])
+        assert self.ll_to_string(res) == 'ablo9381701'
+
+    def test_unicharlist_extension_2(self):
+        def f(n, i):
+            s = 'hello%d' % n
+            assert 0 <= i <= len(s)
+            l = [u'a', u'b']
+            l += s[i:]
+            return ''.join([chr(ord(c)) for c in l])
+        res = self.interpret(f, [9381701, 3])
+        assert self.ll_to_string(res) == 'ablo9381701'
+
+    def test_extend_a_non_char_list_2(self):
+        def f(n, i):
+            s = 'hello%d' % n
+            assert 0 <= i <= len(s)
+            l = ['foo', 'bar']
+            l += s[i:]      # NOT SUPPORTED for now if l is not a list of chars
+            return ''.join(l)
+        py.test.raises(TyperError, self.interpret, f, [9381701, 3])
+
+    def test_charlist_extension_3(self):
+        def f(n, i, j):
+            s = 'hello%d' % n
+            assert 0 <= i <= j <= len(s)
+            l = ['a', 'b']
+            l += s[i:j]
+            return ''.join(l)
+        res = self.interpret(f, [9381701, 3, 7])
+        assert self.ll_to_string(res) == 'ablo93'
+
+    def test_unicharlist_extension_3(self):
+        def f(n, i, j):
+            s = 'hello%d' % n
+            assert 0 <= i <= j <= len(s)
+            l = [u'a', u'b']
+            l += s[i:j]
+            return ''.join([chr(ord(c)) for c in l])
+        res = self.interpret(f, [9381701, 3, 7])
+        assert self.ll_to_string(res) == 'ablo93'
+
+    def test_charlist_extension_4(self):
+        def f(n):
+            s = 'hello%d' % n
+            l = ['a', 'b']
+            l += s[:-1]
+            return ''.join(l)
+        res = self.interpret(f, [9381701])
+        assert self.ll_to_string(res) == 'abhello938170'
+
+    def test_unicharlist_extension_4(self):
+        def f(n):
+            s = 'hello%d' % n
+            l = [u'a', u'b']
+            l += s[:-1]
+            return ''.join([chr(ord(c)) for c in l])
+        res = self.interpret(f, [9381701])
+        assert self.ll_to_string(res) == 'abhello938170'
+
+    def test_charlist_extension_5(self):
+        def f(count):
+            l = ['a', 'b']
+            l += '.' * count     # char * count
+            return ''.join(l)
+        res = self.interpret(f, [7])
+        assert self.ll_to_string(res) == 'ab.......'
+        res = self.interpret(f, [0])
+        assert self.ll_to_string(res) == 'ab'
+
+    def test_unicharlist_extension_5(self):
+        def f(count):
+            l = [u'a', u'b']
+            l += '.' * count     # NON-UNICODE-char * count
+            return ''.join([chr(ord(c)) for c in l])
+        res = self.interpret(f, [7])
+        assert self.ll_to_string(res) == 'ab.......'
+        res = self.interpret(f, [0])
+        assert self.ll_to_string(res) == 'ab'
+
+    def test_charlist_extension_6(self):
+        def f(count):
+            l = ['a', 'b']
+            l += count * '.'     # count * char
+            return ''.join(l)
+        res = self.interpret(f, [7])
+        assert self.ll_to_string(res) == 'ab.......'
+        res = self.interpret(f, [0])
+        assert self.ll_to_string(res) == 'ab'
+
+    def test_extend_a_non_char_list_6(self):
+        def f(count):
+            l = ['foo', 'bar']
+            # NOT SUPPORTED for now if l is not a list of chars
+            l += count * '.'
+            return ''.join(l)
+        py.test.raises(TyperError, self.interpret, f, [5])
+
+    def test_r_short_list(self):
+        from rpython.rtyper.lltypesystem.rffi import r_short
+        from rpython.rlib import rarithmetic
+        def f(i):
+            l = [r_short(0)] * 10
+            l[i+1] = r_short(3)
+            return rarithmetic.widen(l[i])
+        res = self.interpret(f, [3])
+        assert res == 0
+
+    def test_make_new_list(self):
+        class A:
+            def _freeze_(self):
+                return True
+        a1 = A()
+        a2 = A()
+        def f(i):
+            lst = [a1, a1]
+            lst2 = list(lst)
+            lst2.append(a2)
+            return lst2[i] is a2
+        res = self.interpret(f, [1])
+        assert res == False
+        res = self.interpret(f, [2])
+        assert res == True
+
+    def test_immutable_list_out_of_instance(self):
+        for immutable_fields in (["a", "b"], ["a", "b", "y[*]"]):
+            class A(object):
+                _immutable_fields_ = immutable_fields
+            class B(A):
+                pass
+            def f(i):
+                b = B()
+                lst = [i]
+                lst[0] += 1
+                b.y = lst
+                ll_assert(b.y is lst, "copying when reading out the attr?")
+                return b.y[0]
+            res = self.interpret(f, [10])
+            assert res == 11
+            t, rtyper, graph = self.gengraph(f, [int])
+            block = graph.startblock
+            op = block.operations[-1]
+            assert op.opname == 'direct_call'
+            func = op.args[2].value
+            assert ('foldable' in func.func_name) == \
+                   ("y[*]" in immutable_fields)
+
+    def test_hints(self):
+        from rpython.rlib.objectmodel import newlist_hint
+
+        strings = ['abc', 'def']
+        def f(i):
+            z = strings[i]
+            x = newlist_hint(sizehint=13)
+            x += z
+            return ''.join(x)
+
+        res = self.interpret(f, [0])
+        assert self.ll_to_string(res) == 'abc'
+
+    def test_memoryerror(self):
+        def fn(i):
+            lst = [0] * i
+            lst[i-1] = 5
+            return lst[0]
+        res = self.interpret(fn, [1])
+        assert res == 5
+        res = self.interpret(fn, [2])
+        assert res == 0
+        self.interpret_raises(MemoryError, fn, [sys.maxint])
+
+    def test_type_erase_fixed_size(self):
+        class A(object):
+            pass
+        class B(object):
+            pass
+
+        def f():
+            return [A()], [B()]
+
+        t = TranslationContext()
+        s = t.buildannotator().build_types(f, [])
+        rtyper = t.buildrtyper()
+        rtyper.specialize()
+
+        s_A_list = s.items[0]
+        s_B_list = s.items[1]
+
+        r_A_list = rtyper.getrepr(s_A_list)
+        assert isinstance(r_A_list, self.rlist.FixedSizeListRepr)
+        r_B_list = rtyper.getrepr(s_B_list)
+        assert isinstance(r_B_list, self.rlist.FixedSizeListRepr)
+
+        assert r_A_list.lowleveltype == r_B_list.lowleveltype
+
+    def test_type_erase_var_size(self):
+        class A(object):
+            pass
+        class B(object):
+            pass
+
+        def f():
+            la = [A()]
+            lb = [B()]
+            la.append(None)
+            lb.append(None)
+            return la, lb
+
+        t = TranslationContext()
+        s = t.buildannotator().build_types(f, [])
+        rtyper = t.buildrtyper()
+        rtyper.specialize()
+
+        s_A_list = s.items[0]
+        s_B_list = s.items[1]
+
+        r_A_list = rtyper.getrepr(s_A_list)
+        assert isinstance(r_A_list, self.rlist.ListRepr)
+        r_B_list = rtyper.getrepr(s_B_list)
+        assert isinstance(r_B_list, self.rlist.ListRepr)
+
+        assert r_A_list.lowleveltype == r_B_list.lowleveltype
+
+    def test_no_unneeded_refs(self):
+        def fndel(p, q):
+            lis = ["5", "3", "99"]
+            assert q >= 0
+            assert p >= 0
+            del lis[p:q]
+            return lis
+        def fnpop(n):
+            lis = ["5", "3", "99"]
+            while n:
+                lis.pop()
+                n -=1
+            return lis
+        for i in range(2, 3+1):
+            lis = self.interpret(fndel, [0, i])
+            assert list_is_clear(lis, 3-i)
+        for i in range(3):
+            lis = self.interpret(fnpop, [i])
+            assert list_is_clear(lis, 3-i)
+
+    def test_oopspec(self):
+        lst1 = [123, 456]     # non-mutated list
+        def f(i):
+            lst2 = [i]
+            lst2.append(42)    # mutated list
+            return lst1[i] + lst2[i]
+        from rpython.annotator import model as annmodel
+        _, _, graph = self.gengraph(f, [annmodel.SomeInteger(nonneg=True)])
+        block = graph.startblock
+        lst1_getitem_op = block.operations[-3]     # XXX graph fishing
+        lst2_getitem_op = block.operations[-2]
+        func1 = lst1_getitem_op.args[2].value
+        func2 = lst2_getitem_op.args[2].value
+        assert func1.oopspec == 'list.getitem_foldable(l, index)'
+        assert not hasattr(func2, 'oopspec')
+
+    def test_iterate_over_immutable_list(self):
+        from rpython.rtyper import rlist
+        class MyException(Exception):
+            pass
+        lst = list('abcdef')
+        def dummyfn():
+            total = 0
+            for c in lst:
+                total += ord(c)
+            return total
+        #
+        prev = rlist.ll_getitem_foldable_nonneg
+        try:
+            def seen_ok(l, index):
+                if index == 5:
+                    raise KeyError     # expected case
+                return prev(l, index)
+            rlist.ll_getitem_foldable_nonneg = seen_ok
+            e = py.test.raises(LLException, self.interpret, dummyfn, [])
+            assert 'KeyError' in str(e.value)
+        finally:
+            rlist.ll_getitem_foldable_nonneg = prev
+
+    def test_iterate_over_immutable_list_quasiimmut_attr(self):
+        from rpython.rtyper import rlist
+        class MyException(Exception):
+            pass
+        class Foo:
+            _immutable_fields_ = ['lst?[*]']
+            lst = list('abcdef')
+        foo = Foo()
+        def dummyfn():
+            total = 0
+            for c in foo.lst:
+                total += ord(c)
+            return total
+        #
+        prev = rlist.ll_getitem_foldable_nonneg
+        try:
+            def seen_ok(l, index):
+                if index == 5:
+                    raise KeyError     # expected case
+                return prev(l, index)
+            rlist.ll_getitem_foldable_nonneg = seen_ok
+            e = py.test.raises(LLException, self.interpret, dummyfn, [])
+            assert 'KeyError' in str(e.value)
+        finally:
+            rlist.ll_getitem_foldable_nonneg = prev
+
+    def test_iterate_over_mutable_list(self):
+        from rpython.rtyper import rlist
+        class MyException(Exception):
+            pass
+        lst = list('abcdef')
+        def dummyfn():
+            total = 0
+            for c in lst:
+                total += ord(c)
+            lst[0] = 'x'
+            return total
+        #
+        prev = rlist.ll_getitem_foldable_nonneg
+        try:
+            def seen_ok(l, index):
+                if index == 5:
+                    raise KeyError     # expected case
+                return prev(l, index)
+            rlist.ll_getitem_foldable_nonneg = seen_ok
+            res = self.interpret(dummyfn, [])
+            assert res == sum(map(ord, 'abcdef'))
+        finally:
+            rlist.ll_getitem_foldable_nonneg = prev
+
+    def test_extend_was_not_overallocating(self):
+        from rpython.rlib import rgc
+        from rpython.rlib.objectmodel import resizelist_hint
+        from rpython.rtyper.lltypesystem import lltype
+        old_arraycopy = rgc.ll_arraycopy
+        try:
+            GLOB = lltype.GcStruct('GLOB', ('seen', lltype.Signed))
+            glob = lltype.malloc(GLOB, immortal=True)
+            glob.seen = 0
+            def my_arraycopy(*args):
+                glob.seen += 1
+                return old_arraycopy(*args)
+            rgc.ll_arraycopy = my_arraycopy
+            def dummyfn():
+                lst = []
+                i = 0
+                while i < 30:
+                    i += 1
+                    resizelist_hint(lst, i)
+                    lst.append(i)
+                return glob.seen
+            res = self.interpret(dummyfn, [])
+        finally:
+            rgc.ll_arraycopy = old_arraycopy
+        #
+        assert 2 <= res <= 10
+
+    def test_alloc_and_set(self):
+        def fn(i):
+            lst = [0] * r_uint(i)
+            return lst
+        t, rtyper, graph = self.gengraph(fn, [int])
+        block = graph.startblock
+        seen = 0
+        for op in block.operations:
+            if op.opname in ['cast_int_to_uint', 'cast_uint_to_int']:
+                continue
+            assert op.opname == 'direct_call'
+            seen += 1
+        assert seen == 1

--- a/rpython/translator/c/src/mem.c
+++ b/rpython/translator/c/src/mem.c
@@ -5,7 +5,7 @@
 
 /***  tracking raw mallocs and frees for debugging ***/
 
-#ifdef RPY_ASSERT
+#ifdef PYPY_DEBUG_ALLOC
 
 struct pypy_debug_alloc_s {
   struct pypy_debug_alloc_s *next;

--- a/rpython/translator/c/src/mem.h
+++ b/rpython/translator/c/src/mem.h
@@ -57,7 +57,7 @@ static int count_mallocs=0, count_frees=0;
 
 /*** tracking raw mallocs and frees for debugging ***/
 
-#ifndef RPY_ASSERT
+#ifndef PYPY_DEBUG_ALLOC
 
 #  define OP_TRACK_ALLOC_START(addr, r)   /* nothing */
 #  define OP_TRACK_ALLOC_STOP(addr, r)    /* nothing */
@@ -204,7 +204,7 @@ RPY_EXTERN long pypy_asm_stackwalk(void*, void*);
 /* marker for trackgcroot.py, and inhibits tail calls */
 #define pypy_asm_stack_bottom() { asm volatile ("/* GC_STACK_BOTTOM */" : : : \
                                   "memory"); pypy_check_stack_count(); }
-#ifdef RPY_ASSERT
+#ifdef PYPY_DEBUG_ALLOC
 RPY_EXTERN void pypy_check_stack_count(void);
 #else
 static void pypy_check_stack_count(void) { }

--- a/rpython/translator/platform/posix.py
+++ b/rpython/translator/platform/posix.py
@@ -139,7 +139,7 @@ class BasePosix(Platform):
             cflags = ('-flto',) + cflags
 
         # runtime index error check
-        eci.compile_extra = eci.compile_extra + ("-DRPY_LL_ASSERT", )
+        eci.compile_extra = eci.compile_extra + ("-DRPY_ASSERT", )
 
         m = GnuMakefile(path)
         m.exe_name = path.join(exe_name.basename)

--- a/rpython/translator/translator.py
+++ b/rpython/translator/translator.py
@@ -72,13 +72,13 @@ class TranslationContext(object):
             self, policy=policy, keepgoing=self.config.translation.keepgoing)
         return self.annotator
 
-    def buildrtyper(self):
+    def buildrtyper(self, unsafe=False):
         if self.annotator is None:
             raise ValueError("no annotator")
         if self.rtyper is not None:
             raise ValueError("we already have an rtyper")
         from rpython.rtyper.rtyper import RPythonTyper
-        self.rtyper = RPythonTyper(self.annotator)
+        self.rtyper = RPythonTyper(self.annotator, unsafe=unsafe)
         return self.rtyper
 
     def getexceptiontransformer(self):


### PR DESCRIPTION
- change compilation flag from `RPY_LL_ASSERT` to `RPY_ASSERT`
- record "UNSAFE" "keyword" from docstring in translator
- modify flowspace model and pygraph to propagate unsafe state
- change rtyper to propagate unsafe state to rlist
- add unsafe `getitem`/`setitem` functions in low level `rlist`
- modify rlist to check hop's unsafe state, if it is unsafe then
  use unsafe `getitem`/`setitem` functions, ll `rlist` at last
- change `RPY_ASSERT` in `mem.c` flag to `PYPY_DEBUG_ALLOC` because they have different semantic meanings