### PR TITLE
pypy/module/cpyext: va_end should be called before return

### DIFF
--- a/pypy/module/cpyext/src/getargs.c
+++ b/pypy/module/cpyext/src/getargs.c
@@ -1804,6 +1804,7 @@ PyArg_UnpackTuple(PyObject *args, const char *name, Py_ssize_t min, Py_ssize_t m
     if (!PyTuple_Check(args)) {
         PyErr_SetString(PyExc_SystemError,
             "PyArg_UnpackTuple() argument list is not a tuple");
+        va_end(vargs);
         return 0;
     }
     l = PyTuple_GET_SIZE(args);

--- a/pypy/module/cpyext/src/varargwrapper.c
+++ b/pypy/module/cpyext/src/varargwrapper.c
@@ -16,8 +16,10 @@ PyTuple_Pack(Py_ssize_t n, ...)
     for (i = 0; i < n; i++) {
         o = va_arg(vargs, PyObject *);
         Py_INCREF(o);
-        if (PyTuple_SetItem(result, i, o) < 0)
+        if (PyTuple_SetItem(result, i, o) < 0) {
+            va_end(vargs);
             return NULL;
+        }
     }
     va_end(vargs);
     return result;


### PR DESCRIPTION
Fix following bugs reported by static code analysis tools:

- [pypy/module/cpyext/src/getargs.c:1807]: (error) va_list 'vargs' was opened but not closed by va_end().
- [pypy/module/cpyext/src/varargwrapper.c:15]: (error) va_list 'vargs' was opened but not closed by va_end().